### PR TITLE
Serve client and add linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This repository contains a minimal prototype of **KonKon**, a kiosk-mode web app
    ```bash
    node src/server.js
    ```
-3. Open `client/index.html` in Firefox kiosk mode to access the UI.
+3. Serve the frontend:
+   ```bash
+   cd client && npm start
+   ```
+   Then navigate to the printed URL (default http://localhost:3000) in your browser.
 
 This prototype implements the core API endpoint `/api/create-call` which generates a unique room identifier. Clients connect via Socket.IO to exchange signaling messages for WebRTC connections.

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  }
+}

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/client/app.js
+++ b/client/app.js
@@ -23,3 +23,7 @@ function App() {
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(React.createElement(App));
+
+if (typeof module !== 'undefined') {
+  module.exports = App;
+}

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+};

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Frontend for KonKon Web Application",
   "scripts": {
-    "start": "" ,
+    "start": "npx serve -s .",
     "test": "jest"
   },
   "dependencies": {
@@ -12,6 +12,8 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "@testing-library/react": "^14.2.1"
+    "@testing-library/react": "^14.2.1",
+    "eslint": "^8.56.0",
+    "prettier": "^3.0.3"
   }
 }

--- a/client/tests/app.test.js
+++ b/client/tests/app.test.js
@@ -1,0 +1,22 @@
+const React = require('react');
+const { render, fireEvent, screen } = require('@testing-library/react');
+const App = require('../app');
+
+describe('App', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({ roomId: 'test' }) })
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates a call link when clicking the button', async () => {
+    render(React.createElement(App));
+    fireEvent.click(screen.getByText('Create Call'));
+    const link = await screen.findByRole('link');
+    expect(link.getAttribute('href')).toContain('/call/test');
+  });
+});


### PR DESCRIPTION
## Summary
- serve the frontend with `npx serve -s .`
- document how to start the frontend
- set up eslint and prettier in the client
- export `App` for testing
- configure jest for the client and add a basic test

## Testing
- `npm test` in `server` *(fails: jest not found)*
- `npm test` in `client` *(fails: jest not found)*