### PR TITLE
Add sqlite database support

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "socket.io": "^4.7.5",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "sqlite3": "^5.1.6"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -2,15 +2,15 @@ const path = require('path');
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
 
-const rooms = {};
+const { createRoom } = require('./db');
 const app = express();
 app.use(express.json());
 
 app.use(express.static(path.join(__dirname, '../client')));
 
-app.post('/api/create-call', (req, res) => {
+app.post('/api/create-call', async (req, res) => {
   const roomId = uuidv4();
-  rooms[roomId] = { created: Date.now() };
+  await createRoom(roomId);
   res.json({ roomId });
 });
 
@@ -18,4 +18,4 @@ app.get('/call/:roomId', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/call.html'));
 });
 
-module.exports = { app, rooms };
+module.exports = { app };

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -1,0 +1,45 @@
+const sqlite3 = require('sqlite3').verbose();
+
+const db = new sqlite3.Database(':memory:');
+
+// Initialize schema
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS rooms (
+    id TEXT PRIMARY KEY,
+    created INTEGER
+  )`);
+});
+
+function createRoom(id) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      `INSERT INTO rooms (id, created) VALUES (?, ?)`,
+      [id, Date.now()],
+      (err) => (err ? reject(err) : resolve())
+    );
+  });
+}
+
+function getRoom(id) {
+  return new Promise((resolve, reject) => {
+    db.get(`SELECT id, created FROM rooms WHERE id = ?`, [id], (err, row) => {
+      if (err) reject(err);
+      else resolve(row);
+    });
+  });
+}
+
+function deleteRoom(id) {
+  return new Promise((resolve, reject) => {
+    db.run(`DELETE FROM rooms WHERE id = ?`, [id], (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+module.exports = {
+  createRoom,
+  getRoom,
+  deleteRoom,
+};

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const { Server } = require('socket.io');
 const { app } = require('./app');
+const { getRoom } = require('./db');
 
 const server = http.createServer(app);
 const io = new Server(server, {
@@ -10,7 +11,12 @@ const io = new Server(server, {
 });
 
 io.on('connection', (socket) => {
-  socket.on('join-room', (roomId) => {
+  socket.on('join-room', async (roomId) => {
+    const room = await getRoom(roomId);
+    if (!room) {
+      socket.emit('room-not-found');
+      return;
+    }
     socket.join(roomId);
     socket.to(roomId).emit('user-joined', socket.id);
 

--- a/server/tests/app.test.js
+++ b/server/tests/app.test.js
@@ -1,10 +1,32 @@
 const request = require('supertest');
 const { app } = require('../src/app');
+const { getRoom, deleteRoom } = require('../src/db');
 
 describe('POST /api/create-call', () => {
-  it('responds with a roomId', async () => {
+  afterEach(async () => {
+    // cleanup all rooms
+    await deleteRoom(lastRoomId);
+    lastRoomId = null;
+  });
+
+  let lastRoomId;
+
+  it('responds with a roomId and stores the room', async () => {
     const res = await request(app).post('/api/create-call');
     expect(res.statusCode).toBe(200);
     expect(res.body.roomId).toBeDefined();
+    lastRoomId = res.body.roomId;
+
+    const room = await getRoom(lastRoomId);
+    expect(room).toBeDefined();
+    expect(room.id).toBe(lastRoomId);
+  });
+
+  it('deleteRoom removes the room', async () => {
+    const res = await request(app).post('/api/create-call');
+    const roomId = res.body.roomId;
+    await deleteRoom(roomId);
+    const room = await getRoom(roomId);
+    expect(room).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add sqlite3 dependency
- add db.js module with CRUD helpers
- persist rooms in `/api/create-call`
- check for room existence before allowing Socket.IO join
- test room persistence and deletion

## Testing
- `npm test` *(fails: jest not found)*