### PR TITLE
Implement random audio chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a minimal prototype of **KonKon**, a kiosk-mode web app
 
 - **server/** – Express backend with a Socket.IO server.
 - **client/** – Simple React application served as static files.
+- **recorder/** – Node.js utility for capturing video/audio and uploading
+  audio fragments to Kitsu9.
 
 ## Running
 
@@ -19,5 +21,18 @@ This repository contains a minimal prototype of **KonKon**, a kiosk-mode web app
    node src/server.js
    ```
 3. Open `client/index.html` in Firefox kiosk mode to access the UI.
+
+### Recording kiosk sessions
+
+The `recorder` tool captures webcam video and microphone audio to a mounted USB
+drive and uploads the audio fragments for speech recognition. To run it:
+
+```bash
+cd recorder && npm install
+USB_PATH=/mnt/usb node index.js
+```
+
+Set `USB_PATH` to the mount point of your USB storage and optionally
+`RECORD_DURATION` to control the length of the recording in seconds.
 
 This prototype implements the core API endpoint `/api/create-call` which generates a unique room identifier. Clients connect via Socket.IO to exchange signaling messages for WebRTC connections.

--- a/recorder/index.js
+++ b/recorder/index.js
@@ -1,0 +1,59 @@
+const { spawn, spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const ffmpegPath = require('ffmpeg-static');
+const { splitAudio } = require('./splitAudio');
+
+const USB_PATH = process.env.USB_PATH || '/mnt/usb';
+const DURATION = parseInt(process.env.RECORD_DURATION || '30', 10); // seconds
+
+if (!fs.existsSync(USB_PATH)) {
+  console.error('USB path not found:', USB_PATH);
+  process.exit(1);
+}
+
+const sessionId = new Date().toISOString().replace(/[:.]/g, '-');
+const videoFile = path.join(USB_PATH, `session-${sessionId}.mp4`);
+const audioFile = path.join(USB_PATH, `session-${sessionId}.wav`);
+const metaFile = path.join(USB_PATH, `session-${sessionId}.json`);
+
+function extractAudio() {
+  spawnSync(ffmpegPath, [
+    '-y',
+    '-i', videoFile,
+    '-vn',
+    '-acodec', 'pcm_s16le',
+    audioFile
+  ], { stdio: 'inherit' });
+}
+
+function record() {
+  console.log(`Recording ${DURATION}s to ${videoFile}`);
+  const args = [
+    '-y',
+    '-t', String(DURATION),
+    '-f', 'v4l2',
+    '-i', '/dev/video0',
+    '-f', 'alsa',
+    '-i', 'default',
+    '-c:v', 'libx264',
+    '-c:a', 'aac',
+    videoFile
+  ];
+  const proc = spawn(ffmpegPath, args, { stdio: 'inherit' });
+  proc.on('exit', async (code) => {
+    if (code !== 0) {
+      console.error('ffmpeg exited with', code);
+      return;
+    }
+    extractAudio();
+    try {
+      await splitAudio(audioFile, metaFile);
+      console.log('Audio chunks saved to', metaFile);
+    } catch (err) {
+      console.error('splitAudio error:', err);
+    }
+  });
+}
+
+record();

--- a/recorder/package.json
+++ b/recorder/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "konkon-recorder",
+  "version": "0.1.0",
+  "description": "Media recording utility for KonKon",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "ffmpeg-static": "^5.1.0",
+    "fluent-ffmpeg": "^2.1.2",
+    "uuid": "^9.0.1",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/recorder/splitAudio.js
+++ b/recorder/splitAudio.js
@@ -1,0 +1,109 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const ffmpegPath = require('ffmpeg-static');
+const { v4: uuidv4 } = require('uuid');
+const fetch = require('node-fetch');
+
+/**
+ * Detects silence in the input file and splits it into chunks using ffmpeg.
+ * Each chunk is uploaded to the Kitsu9 server.
+ *
+ * @param {string} input - Path to WAV file.
+ * @param {string} metaFile - Path to JSON metadata output.
+ * @returns {Promise<void>}
+ */
+async function splitAudio(input, metaFile) {
+  // Detect silence
+  const detect = spawnSync(ffmpegPath, [
+    '-i', input,
+    '-af', 'silencedetect=noise=-30dB:d=0.5',
+    '-f', 'null',
+    '-'
+  ], { encoding: 'utf8' });
+
+  if (detect.error) {
+    throw detect.error;
+  }
+
+  const events = [];
+  const lines = detect.stderr.split('\n');
+  for (const line of lines) {
+    const mStart = line.match(/silence_start: (\d+\.?\d*)/);
+    const mEnd = line.match(/silence_end: (\d+\.?\d*)/);
+    if (mStart) events.push({ type: 'start', time: parseFloat(mStart[1]) });
+    if (mEnd) events.push({ type: 'end', time: parseFloat(mEnd[1]) });
+  }
+
+  events.sort((a, b) => a.time - b.time);
+  const segments = [];
+  let last = 0;
+  for (const ev of events) {
+    if (ev.type === 'start') {
+      segments.push({ start: last, end: ev.time });
+    } else if (ev.type === 'end') {
+      last = ev.time;
+    }
+  }
+
+  // Determine duration for the final segment
+  const probe = spawnSync(ffmpegPath.replace(/ffmpeg$/, 'ffprobe'), [
+    '-v', 'error',
+    '-show_entries', 'format=duration',
+    '-of', 'default=noprint_wrappers=1:nokey=1',
+    input
+  ], { encoding: 'utf8' });
+  const duration = parseFloat(probe.stdout);
+  if (!isNaN(duration) && last < duration) {
+    segments.push({ start: last, end: duration });
+  }
+
+  // group consecutive segments into chunks of 3-5 segments
+  const groups = [];
+  for (let i = 0; i < segments.length;) {
+    const size = 3 + Math.floor(Math.random() * 3); // 3-5
+    const slice = segments.slice(i, i + size);
+    if (slice.length === 0) break;
+    groups.push({ start: slice[0].start, end: slice[slice.length - 1].end });
+    i += size;
+  }
+
+  const mapping = [];
+  let index = 0;
+  for (const seg of groups) {
+    const id = uuidv4();
+    const outFile = path.join(path.dirname(metaFile), `${id}.wav`);
+    const cut = spawnSync(ffmpegPath, [
+      '-y',
+      '-i', input,
+      '-ss', seg.start.toString(),
+      '-to', seg.end.toString(),
+      '-c', 'copy',
+      outFile
+    ]);
+
+    if (cut.status !== 0) {
+      console.error('ffmpeg split error:', cut.stderr.toString());
+      continue;
+    }
+
+    const buffer = fs.readFileSync(outFile);
+    fs.unlinkSync(outFile);
+    try {
+      await fetch(process.env.KITSU9_URL || 'http://localhost:4000/stt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'audio/wav' },
+        body: buffer
+      });
+    } catch (err) {
+      console.error('Failed to upload chunk:', err.message);
+    }
+
+    mapping.push({ id, index, startTime: seg.start, endTime: seg.end });
+    index++;
+    fs.writeFileSync(metaFile, JSON.stringify(mapping, null, 2));
+  }
+
+}
+
+module.exports = { splitAudio };


### PR DESCRIPTION
## Summary
- document recorder tool in README
- split recorder audio into random 3–5 segment chunks
- store start/end times for each chunk and flush metadata to disk

## Testing
- `npm -C server test` *(fails: jest not found)*