### PR TITLE
Add persistent DB layer and tests

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,8 +1,9 @@
 const path = require('path');
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
+const db = require('./db');
 
-const rooms = {};
+db.init();
 const app = express();
 app.use(express.json());
 
@@ -10,7 +11,7 @@ app.use(express.static(path.join(__dirname, '../client')));
 
 app.post('/api/create-call', (req, res) => {
   const roomId = uuidv4();
-  rooms[roomId] = { created: Date.now() };
+  db.createRoom(roomId);
   res.json({ roomId });
 });
 
@@ -18,4 +19,4 @@ app.get('/call/:roomId', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/call.html'));
 });
 
-module.exports = { app, rooms };
+module.exports = { app };

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const dbFile = process.env.DB_FILE || path.join(__dirname, '../rooms.json');
+
+function readData() {
+  try {
+    const raw = fs.readFileSync(dbFile, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    return { rooms: {} };
+  }
+}
+
+function writeData(data) {
+  fs.writeFileSync(dbFile, JSON.stringify(data, null, 2));
+}
+
+function init() {
+  if (!fs.existsSync(dbFile)) {
+    writeData({ rooms: {} });
+  }
+}
+
+function createRoom(roomId) {
+  const data = readData();
+  data.rooms[roomId] = { created: Date.now() };
+  writeData(data);
+}
+
+function getRoom(roomId) {
+  const data = readData();
+  return data.rooms[roomId];
+}
+
+module.exports = { init, createRoom, getRoom };

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,7 +1,9 @@
 const http = require('http');
 const { Server } = require('socket.io');
 const { app } = require('./app');
+const db = require('./db');
 
+db.init();
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
@@ -11,6 +13,11 @@ const io = new Server(server, {
 
 io.on('connection', (socket) => {
   socket.on('join-room', (roomId) => {
+    const room = db.getRoom(roomId);
+    if (!room) {
+      socket.emit('error', 'Room not found');
+      return;
+    }
     socket.join(roomId);
     socket.to(roomId).emit('user-joined', socket.id);
 

--- a/server/tests/app.test.js
+++ b/server/tests/app.test.js
@@ -1,8 +1,17 @@
 const request = require('supertest');
-const { app } = require('../src/app');
+const fs = require('fs');
+const path = require('path');
 
 describe('POST /api/create-call', () => {
+  const dbPath = path.join(__dirname, 'test-app.json');
+  beforeEach(() => {
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    process.env.DB_FILE = dbPath;
+    jest.resetModules();
+  });
+
   it('responds with a roomId', async () => {
+    const { app } = require('../src/app');
     const res = await request(app).post('/api/create-call');
     expect(res.statusCode).toBe(200);
     expect(res.body.roomId).toBeDefined();

--- a/server/tests/persistence.test.js
+++ b/server/tests/persistence.test.js
@@ -1,0 +1,27 @@
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+
+describe('room persistence', () => {
+  const dbPath = path.join(__dirname, 'test-rooms.json');
+  beforeEach(() => {
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    process.env.DB_FILE = dbPath;
+    jest.resetModules();
+  });
+
+  it('persists rooms across app reload', async () => {
+    const { app } = require('../src/app');
+    const res = await request(app).post('/api/create-call');
+    expect(res.statusCode).toBe(200);
+    const roomId = res.body.roomId;
+
+    // simulate server restart
+    jest.resetModules();
+    process.env.DB_FILE = dbPath;
+    const db = require('../src/db');
+    db.init();
+    const room = db.getRoom(roomId);
+    expect(room).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add simple JSON-based DB module
- use the DB in REST endpoint and socket join
- expand tests for DB persistence

## Testing
- `npm test` *(fails: jest not found)*