### PR TITLE
Implement CORS configuration and tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "socket.io": "^4.7.5",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,10 +1,29 @@
 const path = require('path');
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
+const cors = require('cors');
 
 const rooms = {};
 const app = express();
 app.use(express.json());
+
+const allowedOriginsEnv = process.env.ALLOWED_ORIGINS;
+if (allowedOriginsEnv) {
+  const origins = allowedOriginsEnv.split(',').map((o) => o.trim());
+  app.use(
+    cors({
+      origin: (origin, callback) => {
+        if (!origin || origins.includes(origin)) {
+          callback(null, true);
+        } else {
+          callback(new Error('Not allowed by CORS'));
+        }
+      },
+    })
+  );
+} else {
+  app.use(cors());
+}
 
 app.use(express.static(path.join(__dirname, '../client')));
 
@@ -16,6 +35,15 @@ app.post('/api/create-call', (req, res) => {
 
 app.get('/call/:roomId', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/call.html'));
+});
+
+app.use((err, req, res, next) => {
+  if (err.message === 'Not allowed by CORS') {
+    res.status(403).json({ error: 'CORS Error: Origin not allowed' });
+  } else {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
 });
 
 module.exports = { app, rooms };

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -3,9 +3,12 @@ const { Server } = require('socket.io');
 const { app } = require('./app');
 
 const server = http.createServer(app);
+const allowedOriginsEnv = process.env.ALLOWED_ORIGINS;
 const io = new Server(server, {
   cors: {
-    origin: '*',
+    origin: allowedOriginsEnv
+      ? allowedOriginsEnv.split(',').map((o) => o.trim())
+      : '*',
   },
 });
 

--- a/server/tests/app.test.js
+++ b/server/tests/app.test.js
@@ -8,3 +8,10 @@ describe('POST /api/create-call', () => {
     expect(res.body.roomId).toBeDefined();
   });
 });
+
+describe('Invalid requests', () => {
+  it('returns 404 for unknown endpoint', async () => {
+    const res = await request(app).get('/api/does-not-exist');
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/server/tests/cors.test.js
+++ b/server/tests/cors.test.js
@@ -1,0 +1,15 @@
+process.env.ALLOWED_ORIGINS = 'http://allowed.com';
+const request = require('supertest');
+// clear cached app in case other tests loaded it
+delete require.cache[require.resolve('../src/app')];
+const { app } = require('../src/app');
+
+describe('CORS disallowed origins', () => {
+  it('rejects requests from disallowed origins', async () => {
+    const res = await request(app)
+      .post('/api/create-call')
+      .set('Origin', 'http://notallowed.com');
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toMatch(/CORS/);
+  });
+});


### PR DESCRIPTION
## Summary
- use `ALLOWED_ORIGINS` env variable to configure express CORS
- apply same origin list to socket.io server
- add generic error handler middleware
- expand tests to cover bad requests and disallowed origins
- declare `cors` dependency

## Testing
- `npm test` *(fails: `jest` not found)*