### PR TITLE
Document recorder usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,30 @@ This repository contains a minimal prototype of **KonKon**, a kiosk-mode web app
 3. Open `client/index.html` in Firefox kiosk mode to access the UI.
 
 This prototype implements the core API endpoint `/api/create-call` which generates a unique room identifier. Clients connect via Socket.IO to exchange signaling messages for WebRTC connections.
+
+## Директория `recorder/`
+
+В каталоге `recorder/` содержится утилита для записи аудио и видео. Скрипт `index.js` сохраняет файлы на подключённый USB-носитель и при наличии сети может передавать их на сервер Kitsu9.
+
+### Параметры
+
+- `USB_PATH` — путь к смонтированному носителю.
+- `RECORD_DURATION` — длительность записи в секундах.
+- `KITSU9_URL` — адрес API для загрузки файла.
+
+### Пример запуска в Puppy Linux
+
+```bash
+USB_PATH=/mnt/sdb1 RECORD_DURATION=30 KITSU9_URL=https://kitsu9.example \
+node recorder/index.js
+```
+
+После завершения на носителе появляются `record.wav` и `record.mp3`: первая — оригинальная запись, вторая — сжатая копия.
+
+### Установка зависимостей
+
+Требуемые пакеты (например, `ffmpeg-static`) устанавливаются отдельно после подключения к сети:
+
+```bash
+cd recorder && npm install
+```


### PR DESCRIPTION
## Summary
- explain the purpose of `recorder/` directory
- document `USB_PATH`, `RECORD_DURATION`, `KITSU9_URL`
- add a Puppy Linux example that shows which files are produced
- mention installing ffmpeg-static and other dependencies after network access

## Testing
- `git log -1 --stat`