### PR TITLE
Implement CORS env config and error middleware

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "supertest": "^6.3.4"
+    "supertest": "^6.3.4",
+    "socket.io-client": "^4.7.5"
   }
 }

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -18,4 +18,21 @@ app.get('/call/:roomId', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/call.html'));
 });
 
+app.get('/api/error', (req, res, next) => {
+  const err = new Error('Test error');
+  err.status = 500;
+  next(err);
+});
+
+app.use((req, res, next) => {
+  const err = new Error('Not Found');
+  err.status = 404;
+  next(err);
+});
+
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  res.status(status).json({ code: status, message: err.message });
+});
+
 module.exports = { app, rooms };

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -3,9 +3,13 @@ const { Server } = require('socket.io');
 const { app } = require('./app');
 
 const server = http.createServer(app);
+const allowedOriginsEnv = process.env.ALLOWED_ORIGINS;
+const allowedOrigins = allowedOriginsEnv
+  ? allowedOriginsEnv.split(',').map((o) => o.trim()).filter(Boolean)
+  : '*';
 const io = new Server(server, {
   cors: {
-    origin: '*',
+    origin: allowedOrigins,
   },
 });
 
@@ -24,3 +28,5 @@ const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
+
+module.exports = { server, io };

--- a/server/tests/app.test.js
+++ b/server/tests/app.test.js
@@ -8,3 +8,17 @@ describe('POST /api/create-call', () => {
     expect(res.body.roomId).toBeDefined();
   });
 });
+
+describe('error handling', () => {
+  it('returns JSON for not found', async () => {
+    const res = await request(app).get('/nonexistent');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ code: 404, message: 'Not Found' });
+  });
+
+  it('returns JSON for thrown errors', async () => {
+    const res = await request(app).get('/api/error');
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ code: 500, message: 'Test error' });
+  });
+});

--- a/server/tests/origin.test.js
+++ b/server/tests/origin.test.js
@@ -1,0 +1,33 @@
+const ioClient = require('socket.io-client');
+
+describe('socket.io CORS', () => {
+  let server, io, port;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.ALLOWED_ORIGINS = 'http://allowed.com';
+    process.env.PORT = 0;
+    ({ server, io } = require('../src/server'));
+    port = server.address().port;
+  });
+
+  afterEach((done) => {
+    io.close();
+    server.close(done);
+  });
+
+  it('rejects disallowed origin', (done) => {
+    const socket = ioClient(`http://localhost:${port}`, {
+      extraHeaders: { origin: 'http://notallowed.com' },
+      transports: ['websocket'],
+    });
+
+    socket.on('connect', () => {
+      done(new Error('should not connect'));
+    });
+    socket.on('connect_error', () => {
+      socket.close();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- read `ALLOWED_ORIGINS` from env in the websocket server
- add error handling middleware in express app
- export server instance and write tests for errors and cors

## Testing
- `npm test` *(fails: `jest` not found)*