### PR TITLE
Implement persistent room storage

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "socket.io": "^4.7.5",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "sqlite3": "^5.1.6"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,21 +1,25 @@
 const path = require('path');
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
+const { createRoom } = require('./db');
 
-const rooms = {};
 const app = express();
 app.use(express.json());
 
 app.use(express.static(path.join(__dirname, '../client')));
 
-app.post('/api/create-call', (req, res) => {
+app.post('/api/create-call', async (req, res) => {
   const roomId = uuidv4();
-  rooms[roomId] = { created: Date.now() };
-  res.json({ roomId });
+  try {
+    await createRoom(roomId);
+    res.json({ roomId });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to create room' });
+  }
 });
 
 app.get('/call/:roomId', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/call.html'));
 });
 
-module.exports = { app, rooms };
+module.exports = { app };

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -1,0 +1,38 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = path.join(__dirname, '../rooms.db');
+const db = new sqlite3.Database(dbPath);
+
+db.serialize(() => {
+  db.run('CREATE TABLE IF NOT EXISTS rooms (id TEXT PRIMARY KEY, created INTEGER)');
+});
+
+function createRoom(id) {
+  return new Promise((resolve, reject) => {
+    db.run('INSERT INTO rooms(id, created) VALUES(?, ?)', [id, Date.now()], function(err) {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+function getRoom(id) {
+  return new Promise((resolve, reject) => {
+    db.get('SELECT * FROM rooms WHERE id = ?', [id], (err, row) => {
+      if (err) return reject(err);
+      resolve(row || null);
+    });
+  });
+}
+
+function deleteRoom(id) {
+  return new Promise((resolve, reject) => {
+    db.run('DELETE FROM rooms WHERE id = ?', [id], function(err) {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+module.exports = { db, createRoom, getRoom, deleteRoom };

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const { Server } = require('socket.io');
 const { app } = require('./app');
+const { getRoom } = require('./db');
 
 const server = http.createServer(app);
 const io = new Server(server, {
@@ -10,7 +11,12 @@ const io = new Server(server, {
 });
 
 io.on('connection', (socket) => {
-  socket.on('join-room', (roomId) => {
+  socket.on('join-room', async (roomId) => {
+    const room = await getRoom(roomId);
+    if (!room) {
+      socket.emit('error', 'Room not found');
+      return;
+    }
     socket.join(roomId);
     socket.to(roomId).emit('user-joined', socket.id);
 

--- a/server/tests/app.test.js
+++ b/server/tests/app.test.js
@@ -1,10 +1,20 @@
 const request = require('supertest');
 const { app } = require('../src/app');
+const { getRoom, db } = require('../src/db');
+
+beforeEach((done) => {
+  db.run('DELETE FROM rooms', done);
+});
+
+afterAll((done) => {
+  db.close(done);
+});
 
 describe('POST /api/create-call', () => {
-  it('responds with a roomId', async () => {
+  it('creates a room in the database', async () => {
     const res = await request(app).post('/api/create-call');
     expect(res.statusCode).toBe(200);
-    expect(res.body.roomId).toBeDefined();
+    const room = await getRoom(res.body.roomId);
+    expect(room).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- store rooms in SQLite via new `db.js`
- create rooms using the database
- verify room existence in socket handler
- test that `POST /api/create-call` persists rooms
- add sqlite3 dependency

## Testing
- `npm test` *(fails: `jest` not found)*